### PR TITLE
Port Bio.Restriction to BioSmalltalk

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -3,6 +3,7 @@ SmalltalkCISpec {
     SCIMetacelloLoadSpec {
       #baseline : 'BioSmalltalk',
       #directory : 'repository',
+      #onConflict : #useIncoming,
       #platforms : [ #pharo ]
     }
   ],

--- a/repository/BaselineOfBioSmalltalk/BaselineOfBioSmalltalk.class.st
+++ b/repository/BaselineOfBioSmalltalk/BaselineOfBioSmalltalk.class.st
@@ -112,7 +112,7 @@ BaselineOfBioSmalltalk >> baselineCommonPackages: spec [
 																	requires: #('CommonUtils' 'StringExtensions' 'PetitParser2Core' 'PolyMath' 'XMLParser' 'NeedlemanWunsch');
 																	includes: #('BioPharoCommon') ];
 			package: 'BioToolsSamples' 			with: [ spec requires: #('BioTools' 'BioEntrez' 'BioParsers' ). ];
-			package: 'BioTools-Tests' 			with: [ spec requires: #('BioTools' ). ];
+			package: 'BioTools-Tests' 			with: [ spec requires: #('BioTools' 'BioSupport' ). ];
 			package: 'BioWrapperTests' 			with: [ spec requires: #('BioTools-Tests' ) ];
 			package: 'BioPhysics'        	with: [ spec requires: #('BioTools') ];
 			package: 'BioWrappers' 				with: [ spec requires: #('BioTools' ) ]

--- a/repository/BioFormatters/BioRestrictionMapFormatter.class.st
+++ b/repository/BioFormatters/BioRestrictionMapFormatter.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : 'BioRestrictionMapFormatter',
+	#superclass : 'BioFormatter',
+	#category : 'BioFormatters-Restriction',
+	#package : 'BioFormatters',
+	#tag : 'Restriction'
+}
+
+{ #category : 'formatting' }
+BioRestrictionMapFormatter >> format: aSequence enzymes: aCollection [
+	| stream sites |
+	stream := WriteStream on: String new.
+	stream nextPutAll: 'Restriction Map for: '; nextPutAll: aSequence name asString; cr.
+	stream nextPutAll: 'Length: '; nextPutAll: aSequence size asString; cr.
+	stream nextPutAll: 'Topology: '; nextPutAll: (aSequence isCircular ifTrue: [ 'Circular' ] ifFalse: [ 'Linear' ]); cr.
+	stream cr.
+
+	sites := OrderedCollection new.
+	aCollection do: [ :enzyme |
+		(enzyme searchIn: aSequence) do: [ :pos |
+			sites add: { pos . enzyme name . pos + enzyme cut5 } ] ].
+
+	sites sort: [ :a :b | a first < b first ].
+
+	stream nextPutAll: 'Site Index', (Character tab asString), 'Enzyme', (Character tab asString), 'Cut Position'; cr.
+	sites do: [ :each |
+		stream nextPutAll: each first asString; tab; nextPutAll: each second asString; tab; nextPutAll: each third asString; cr ].
+
+	^ stream contents
+]

--- a/repository/BioParsers/BioREBASEParser.class.st
+++ b/repository/BioParsers/BioREBASEParser.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : 'BioREBASEParser',
+	#superclass : 'BioAbstractParser',
+	#category : 'BioParsers-Restriction',
+	#package : 'BioParsers',
+	#tag : 'Restriction'
+}
+
+{ #category : 'parsing' }
+BioREBASEParser >> parse: aStream [
+	"Parse REBASE emboss_e.dat format.
+	Example format:
+	# Name  Site  Cut5  Cut3
+	EcoRI	GAATTC	1	5
+	"
+	| line |
+	[ aStream atEnd ] whileFalse: [
+		line := aStream nextLine.
+		(line beginsWith: '#') ifFalse: [
+			| tokens |
+			tokens := line findTokens: Character tab asString.
+			tokens size >= 4 ifTrue: [
+				| enzyme |
+				enzyme := BioRestrictionEnzyme new.
+				enzyme name: (tokens at: 1).
+				enzyme site: (tokens at: 2).
+				enzyme cut5: (tokens at: 3) asInteger.
+				enzyme cut3: (tokens at: 4) asInteger.
+				BioRestrictionEnzyme register: enzyme ] ] ]
+]

--- a/repository/BioSupport/BioCatalysis.class.st
+++ b/repository/BioSupport/BioCatalysis.class.st
@@ -17,8 +17,9 @@ BioCatalysis >> enzyme [
 ]
 
 { #category : 'accessing' }
-BioCatalysis >> enzyme: anObject [
-	enzyme := anObject
+BioCatalysis >> enzyme: anEnzyme [
+	enzyme := anEnzyme.
+	anEnzyme addCatalysis: self
 ]
 
 { #category : 'accessing' }
@@ -37,6 +38,7 @@ BioCatalysis >> reaction [
 ]
 
 { #category : 'accessing' }
-BioCatalysis >> reaction: anObject [
-	reaction := anObject
+BioCatalysis >> reaction: aReaction [
+	reaction := aReaction.
+	aReaction addCatalysis: self
 ]

--- a/repository/BioSupport/BioCatalysis.class.st
+++ b/repository/BioSupport/BioCatalysis.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : 'BioCatalysis',
+	#superclass : 'BioObject',
+	#instVars : [
+		'enzyme',
+		'reaction',
+		'michaelisConstant'
+	],
+	#category : 'BioSupport-Core',
+	#package : 'BioSupport',
+	#tag : 'Core'
+}
+
+{ #category : 'accessing' }
+BioCatalysis >> enzyme [
+	^ enzyme
+]
+
+{ #category : 'accessing' }
+BioCatalysis >> enzyme: anObject [
+	enzyme := anObject
+]
+
+{ #category : 'accessing' }
+BioCatalysis >> michaelisConstant [
+	^ michaelisConstant
+]
+
+{ #category : 'accessing' }
+BioCatalysis >> michaelisConstant: anObject [
+	michaelisConstant := anObject
+]
+
+{ #category : 'accessing' }
+BioCatalysis >> reaction [
+	^ reaction
+]
+
+{ #category : 'accessing' }
+BioCatalysis >> reaction: anObject [
+	reaction := anObject
+]

--- a/repository/BioSupport/BioReaction.class.st
+++ b/repository/BioSupport/BioReaction.class.st
@@ -14,8 +14,10 @@ Class {
 
 { #category : 'accessing' }
 BioReaction >> addCatalysis: aBioCatalysis [
-	self catalyses add: aBioCatalysis
-]
+	(self catalyses includes: aBioCatalysis) ifFalse: [
+		self catalyses add: aBioCatalysis.
+		aBioCatalysis reaction == self ifFalse: [ aBioCatalysis reaction: self ] ]
+}
 
 { #category : 'accessing' }
 BioReaction >> addProduct: aBioSequence [
@@ -30,7 +32,7 @@ BioReaction >> addSubstrate: aBioSequence [
 { #category : 'accessing' }
 BioReaction >> catalyses [
 	^ catalyses ifNil: [ catalyses := OrderedCollection new ]
-]
+}
 
 { #category : 'accessing' }
 BioReaction >> enzymes [
@@ -55,4 +57,4 @@ BioReaction >> products [
 { #category : 'accessing' }
 BioReaction >> substrates [
 	^ substrates ifNil: [ substrates := OrderedCollection new ]
-]
+}

--- a/repository/BioSupport/BioReaction.class.st
+++ b/repository/BioSupport/BioReaction.class.st
@@ -1,0 +1,58 @@
+Class {
+	#name : 'BioReaction',
+	#superclass : 'BioObject',
+	#instVars : [
+		'name',
+		'substrates',
+		'products',
+		'catalyses'
+	],
+	#category : 'BioSupport-Core',
+	#package : 'BioSupport',
+	#tag : 'Core'
+}
+
+{ #category : 'accessing' }
+BioReaction >> addCatalysis: aBioCatalysis [
+	self catalyses add: aBioCatalysis
+]
+
+{ #category : 'accessing' }
+BioReaction >> addProduct: aBioSequence [
+	self products add: aBioSequence
+]
+
+{ #category : 'accessing' }
+BioReaction >> addSubstrate: aBioSequence [
+	self substrates add: aBioSequence
+]
+
+{ #category : 'accessing' }
+BioReaction >> catalyses [
+	^ catalyses ifNil: [ catalyses := OrderedCollection new ]
+]
+
+{ #category : 'accessing' }
+BioReaction >> enzymes [
+	^ self catalyses collect: [ :each | each enzyme ]
+]
+
+{ #category : 'accessing' }
+BioReaction >> name [
+	^ name
+]
+
+{ #category : 'accessing' }
+BioReaction >> name: anObject [
+	name := anObject
+]
+
+{ #category : 'accessing' }
+BioReaction >> products [
+	^ products ifNil: [ products := OrderedCollection new ]
+]
+
+{ #category : 'accessing' }
+BioReaction >> substrates [
+	^ substrates ifNil: [ substrates := OrderedCollection new ]
+]

--- a/repository/BioTools-Tests/BioRestrictionTest.class.st
+++ b/repository/BioTools-Tests/BioRestrictionTest.class.st
@@ -35,22 +35,19 @@ BioRestrictionTest >> testCircularDigest [
 		cut3: 5;
 		yourself.
 
-	"Site spanning the origin: TTC...GAA"
-	seq := (BioSequence newDNA: 'AATTCAAAAAAGAA') asCircular.
-	fragments := seq digestWithEnzyme: enzyme.
+	"GAATTC at index 1 (GAATTC...) and spanning origin (TTC...GAA)"
+	"Sequence: GAATTC AAAAAA TTC"
+	"123456 789012 131415"
+	seq := (BioSequence newDNA: 'GAATTCAAAAAATTC') asCircular.
+	fragments := seq digestWithEnzymes: (OrderedCollection with: enzyme).
 
 	self assert: fragments size equals: 2.
-	"Cut at G^AATTC. Site 1 is at index 1: GAATTC. Cut at 1+1=2.
-	Site 2 is at index 13: GAATTC (spans 13, 14, 1, 2, 3, 4). Cut at 13+1=14.
-	Fragments: from 2 to 13, and from 14 to 1 (size 14 - 13 + 1 = 2? No, 14 to 1 is 14, 1)."
-	"Wait, let's re-calculate:
-	Sites at 1 and 13.
-	Cuts at 2 and 14.
-	Fragment 1: from 2 to 14-1 = 2 to 13 (AAAAAAGAA).
-	Fragment 2: from 14 to 2-1 = 14 to 1 (AATTCG)."
+	"Sites: 1 (GAATTC), 13 (TTCGAA spanning origin)"
+	"Cuts at 1+1=2 and 13+1=14"
+	"Fragment 1: 2 to 13 -> AATTCAAAAAAT"
+	"Fragment 2: 14 to 1 -> TC G"
 
-	self assert: fragments first asString equals: 'AAAAAAGAA'.
-	self assert: (fragments anySatisfy: [ :f | f asString = 'AATTC' ]). "Depending on exact wrap-around"
+	self assert: (fragments collect: #asString) asSet equals: #('AATTCAAAAAAT' 'TCG') asSet
 ]
 
 { #category : 'testing' }
@@ -85,4 +82,33 @@ BioRestrictionTest >> testIUPACSearch [
 	self assert: sites size equals: 2.
 	self assert: (sites includes: 1).
 	self assert: (sites includes: 9).
+]
+
+{ #category : 'testing' }
+BioRestrictionTest >> testMultiEnzymeDigest [
+	| seq enzymes fragments |
+	enzymes := OrderedCollection new.
+	enzymes add: (BioRestrictionEnzyme new name: 'E1'; site: 'AAA'; cut5: 1).
+	enzymes add: (BioRestrictionEnzyme new name: 'E2'; site: 'CCC'; cut5: 1).
+
+	seq := BioSequence newDNA: 'GAAAGCCCG'.
+	fragments := seq digestWith: enzymes.
+
+	self assert: fragments size equals: 3.
+	self assert: fragments first asString equals: 'GA'.
+	self assert: fragments second asString equals: 'AAGCC'.
+	self assert: fragments third asString equals: 'CG'.
+]
+
+{ #category : 'testing' }
+BioRestrictionTest >> testLinearBounds [
+	| enzyme seq sites |
+	enzyme := BioRestrictionEnzyme new site: 'GAATTC'.
+	seq := BioSequence newDNA: 'GAATT'. "Too short"
+	sites := enzyme searchIn: seq.
+	self assert: sites isEmpty.
+
+	seq := BioSequence newDNA: 'GAATTC'. "Exactly site size"
+	sites := enzyme searchIn: seq.
+	self assert: sites size equals: 1.
 ]

--- a/repository/BioTools-Tests/BioRestrictionTest.class.st
+++ b/repository/BioTools-Tests/BioRestrictionTest.class.st
@@ -1,0 +1,88 @@
+Class {
+	#name : 'BioRestrictionTest',
+	#superclass : 'BioAbstractTest',
+	#category : 'BioTools-Tests-Restriction',
+	#package : 'BioTools-Tests',
+	#tag : 'Restriction'
+}
+
+{ #category : 'testing' }
+BioRestrictionTest >> testEcoRIDigest [
+	| seq enzyme fragments |
+	enzyme := BioRestrictionEnzyme new
+		name: 'EcoRI';
+		site: 'GAATTC';
+		cut5: 1;
+		cut3: 5;
+		yourself.
+	BioRestrictionEnzyme register: enzyme.
+
+	seq := BioSequence newDNA: 'AAAAAGAATTCTTTTT'.
+	fragments := seq digestWith: 'EcoRI'.
+
+	self assert: fragments size equals: 2.
+	self assert: fragments first asString equals: 'AAAAAG'.
+	self assert: fragments second asString equals: 'AATTCTTTTT'.
+]
+
+{ #category : 'testing' }
+BioRestrictionTest >> testCircularDigest [
+	| seq enzyme fragments |
+	enzyme := BioRestrictionEnzyme new
+		name: 'EcoRI';
+		site: 'GAATTC';
+		cut5: 1;
+		cut3: 5;
+		yourself.
+
+	"Site spanning the origin: TTC...GAA"
+	seq := (BioSequence newDNA: 'AATTCAAAAAAGAA') asCircular.
+	fragments := seq digestWithEnzyme: enzyme.
+
+	self assert: fragments size equals: 2.
+	"Cut at G^AATTC. Site 1 is at index 1: GAATTC. Cut at 1+1=2.
+	Site 2 is at index 13: GAATTC (spans 13, 14, 1, 2, 3, 4). Cut at 13+1=14.
+	Fragments: from 2 to 13, and from 14 to 1 (size 14 - 13 + 1 = 2? No, 14 to 1 is 14, 1)."
+	"Wait, let's re-calculate:
+	Sites at 1 and 13.
+	Cuts at 2 and 14.
+	Fragment 1: from 2 to 14-1 = 2 to 13 (AAAAAAGAA).
+	Fragment 2: from 14 to 2-1 = 14 to 1 (AATTCG)."
+
+	self assert: fragments first asString equals: 'AAAAAAGAA'.
+	self assert: (fragments anySatisfy: [ :f | f asString = 'AATTC' ]). "Depending on exact wrap-around"
+]
+
+{ #category : 'testing' }
+BioRestrictionTest >> testManyToManyRelationship [
+	| enzyme reaction catalysis |
+	enzyme := BioEnzyme new name: 'TestEnzyme'.
+	reaction := BioReaction new name: 'TestReaction'.
+	catalysis := BioCatalysis new.
+	catalysis enzyme: enzyme.
+	catalysis reaction: reaction.
+	catalysis michaelisConstant: 0.5.
+
+	enzyme addCatalysis: catalysis.
+	reaction addCatalysis: catalysis.
+
+	self assert: (enzyme catalyzesReaction: reaction).
+	self assert: (reaction enzymes includes: enzyme).
+	self assert: (enzyme michaelisConstantForReaction: reaction) equals: 0.5.
+]
+
+{ #category : 'testing' }
+BioRestrictionTest >> testIUPACSearch [
+	| enzyme seq sites |
+	enzyme := BioRestrictionEnzyme new
+		name: 'HincII';
+		site: 'GTYRAC'; "Y=C|T, R=A|G"
+		yourself.
+
+	seq := BioSequence newDNA: 'GTCGACGGGTTGAC'.
+	sites := enzyme searchIn: seq.
+
+	self assert: sites size equals: 2.
+	self assert: (sites includes: 1).
+	self assert: (sites includes: 9).
+]

--- a/repository/BioTools/BioCircularSequence.class.st
+++ b/repository/BioTools/BioCircularSequence.class.st
@@ -1,0 +1,86 @@
+Class {
+	#name : 'BioCircularSequence',
+	#superclass : 'BioObject',
+	#instVars : [
+		'sequence'
+	],
+	#category : 'BioTools-Sequences',
+	#package : 'BioTools',
+	#tag : 'Sequences'
+}
+
+{ #category : 'instance creation' }
+BioCircularSequence class >> on: aBioSequence [
+	^ self new
+		sequence: aBioSequence;
+		yourself
+]
+
+{ #category : 'accessing' }
+BioCircularSequence >> at: anIndex [
+	| size |
+	size := sequence size.
+	^ sequence at: ((anIndex - 1) \\ size) + 1
+]
+
+{ #category : 'copying' }
+BioCircularSequence >> copyFrom: start to: stop [
+	| size result |
+	size := sequence size.
+	result := String new: (stop - start + 1).
+	start to: stop do: [ :i |
+		result at: (i - start + 1) put: (self at: i) ].
+	^ sequence class newWith: result alphabet: sequence alphabet
+]
+
+{ #category : 'accessing' }
+BioCircularSequence >> sequence [
+	^ sequence
+]
+
+{ #category : 'accessing' }
+BioCircularSequence >> sequence: anObject [
+	sequence := anObject
+]
+
+{ #category : 'accessing' }
+BioCircularSequence >> size [
+	^ sequence size
+]
+
+{ #category : 'searching' }
+BioCircularSequence >> indicesOfSubstring: aString [
+	"Search for aString in the circular sequence.
+	We search in sequence + sequence(1 to: aString size - 1) to cover wrap-around."
+	| searchString size sites |
+	size := sequence size.
+	searchString := sequence asString , (sequence asString copyFrom: 1 to: (aString size - 1 min: size)).
+	sites := searchString indicesOfSubstring: aString.
+	^ sites select: [ :each | each <= size ]
+]
+
+{ #category : 'searching' }
+BioCircularSequence >> digestWith: anEnzymeOrName [
+	| enzyme |
+	enzyme := anEnzymeOrName isString
+		ifTrue: [ BioRestrictionEnzyme at: anEnzymeOrName ]
+		ifFalse: [ anEnzymeOrName ].
+	^ self digestWithEnzyme: enzyme
+]
+
+{ #category : 'searching' }
+BioCircularSequence >> digestWithEnzyme: anEnzyme [
+	| sites fragments |
+	sites := anEnzyme searchIn: self.
+	sites isEmpty ifTrue: [ ^ OrderedCollection with: self sequence ].
+
+	fragments := OrderedCollection new.
+	1 to: sites size do: [ :i |
+		| startCut endCut |
+		startCut := (sites at: i) + anEnzyme cut5.
+		endCut := i < sites size
+			ifTrue: [ (sites at: i + 1) + anEnzyme cut5 ]
+			ifFalse: [ (sites at: 1) + anEnzyme cut5 + self size ].
+		fragments add: (self copyFrom: startCut to: endCut - 1) ].
+	^ fragments
+]

--- a/repository/BioTools/BioCircularSequence.class.st
+++ b/repository/BioTools/BioCircularSequence.class.st
@@ -43,6 +43,11 @@ BioCircularSequence >> sequence: anObject [
 	sequence := anObject
 ]
 
+{ #category : 'testing' }
+BioCircularSequence >> isCircular [
+	^ true
+]
+
 { #category : 'accessing' }
 BioCircularSequence >> size [
 	^ sequence size
@@ -60,27 +65,46 @@ BioCircularSequence >> indicesOfSubstring: aString [
 ]
 
 { #category : 'searching' }
-BioCircularSequence >> digestWith: anEnzymeOrName [
-	| enzyme |
-	enzyme := anEnzymeOrName isString
-		ifTrue: [ BioRestrictionEnzyme at: anEnzymeOrName ]
-		ifFalse: [ anEnzymeOrName ].
-	^ self digestWithEnzyme: enzyme
+BioCircularSequence >> digestWith: anEnzymeCollectionOrName [
+	| enzymes |
+	enzymes := (anEnzymeCollectionOrName isCollection and: [ anEnzymeCollectionOrName isString not ])
+		ifTrue: [ anEnzymeCollectionOrName collect: [ :each | self resolveEnzyme: each ] ]
+		ifFalse: [ OrderedCollection with: (self resolveEnzyme: anEnzymeCollectionOrName) ].
+	^ self digestWithEnzymes: enzymes
 ]
 
 { #category : 'searching' }
-BioCircularSequence >> digestWithEnzyme: anEnzyme [
-	| sites fragments |
-	sites := anEnzyme searchIn: self.
-	sites isEmpty ifTrue: [ ^ OrderedCollection with: self sequence ].
+BioCircularSequence >> resolveEnzyme: anEnzymeOrName [
+	^ anEnzymeOrName isString
+		ifTrue: [ BioRestrictionEnzyme at: anEnzymeOrName ]
+		ifFalse: [ anEnzymeOrName ]
+]
+
+{ #category : 'searching' }
+BioCircularSequence >> restrictionMapReportWith: aCollectionOfEnzymes [
+	| enzymes |
+	enzymes := aCollectionOfEnzymes collect: [ :each | self resolveEnzyme: each ].
+	^ BioRestrictionMapFormatter new format: self enzymes: enzymes
+]
+
+{ #category : 'searching' }
+BioCircularSequence >> digestWithEnzymes: aCollectionOfEnzymes [
+	| allCutSites fragments |
+	allCutSites := Set new.
+	aCollectionOfEnzymes do: [ :enzyme |
+		(enzyme searchIn: self) do: [ :siteIndex |
+			allCutSites add: siteIndex + enzyme cut5 ] ].
+
+	allCutSites isEmpty ifTrue: [ ^ OrderedCollection with: self sequence ].
 
 	fragments := OrderedCollection new.
-	1 to: sites size do: [ :i |
+	allCutSites := allCutSites asSortedCollection asOrderedCollection.
+	1 to: allCutSites size do: [ :i |
 		| startCut endCut |
-		startCut := (sites at: i) + anEnzyme cut5.
-		endCut := i < sites size
-			ifTrue: [ (sites at: i + 1) + anEnzyme cut5 ]
-			ifFalse: [ (sites at: 1) + anEnzyme cut5 + self size ].
+		startCut := allCutSites at: i.
+		endCut := i < allCutSites size
+			ifTrue: [ allCutSites at: i + 1 ]
+			ifFalse: [ (allCutSites at: 1) + self size ].
 		fragments add: (self copyFrom: startCut to: endCut - 1) ].
 	^ fragments
 ]

--- a/repository/BioTools/BioEnzyme.class.st
+++ b/repository/BioTools/BioEnzyme.class.st
@@ -11,25 +11,27 @@ Class {
 
 { #category : 'accessing' }
 BioEnzyme >> addCatalysis: aBioCatalysis [
-	self catalyses add: aBioCatalysis
-]
+	(self catalyses includes: aBioCatalysis) ifFalse: [
+		self catalyses add: aBioCatalysis.
+		aBioCatalysis enzyme == self ifFalse: [ aBioCatalysis enzyme: self ] ]
+}
 
 { #category : 'accessing' }
 BioEnzyme >> catalyses [
 	^ catalyses ifNil: [ catalyses := OrderedCollection new ]
-]
+}
 
 { #category : 'accessing' }
 BioEnzyme >> catalyzesReaction: aBioReaction [
 	^ self reactions includes: aBioReaction
-]
+}
 
 { #category : 'accessing' }
 BioEnzyme >> michaelisConstantForReaction: aBioReaction [
 	^ (self catalyses detect: [ :each | each reaction = aBioReaction ] ifNone: [ ^ nil ]) michaelisConstant
-]
+}
 
 { #category : 'accessing' }
 BioEnzyme >> reactions [
 	^ self catalyses collect: [ :each | each reaction ]
-]
+}

--- a/repository/BioTools/BioEnzyme.class.st
+++ b/repository/BioTools/BioEnzyme.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : 'BioEnzyme',
+	#superclass : 'BioProtein',
+	#instVars : [
+		'catalyses'
+	],
+	#category : 'BioTools-Restriction',
+	#package : 'BioTools',
+	#tag : 'Restriction'
+}
+
+{ #category : 'accessing' }
+BioEnzyme >> addCatalysis: aBioCatalysis [
+	self catalyses add: aBioCatalysis
+]
+
+{ #category : 'accessing' }
+BioEnzyme >> catalyses [
+	^ catalyses ifNil: [ catalyses := OrderedCollection new ]
+]
+
+{ #category : 'accessing' }
+BioEnzyme >> catalyzesReaction: aBioReaction [
+	^ self reactions includes: aBioReaction
+]
+
+{ #category : 'accessing' }
+BioEnzyme >> michaelisConstantForReaction: aBioReaction [
+	^ (self catalyses detect: [ :each | each reaction = aBioReaction ] ifNone: [ ^ nil ]) michaelisConstant
+]
+
+{ #category : 'accessing' }
+BioEnzyme >> reactions [
+	^ self catalyses collect: [ :each | each reaction ]
+]

--- a/repository/BioTools/BioProtein.class.st
+++ b/repository/BioTools/BioProtein.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'BioProtein',
+	#superclass : 'BioSequence',
+	#category : 'BioTools-Sequences',
+	#package : 'BioTools',
+	#tag : 'Sequences'
+}
+
+{ #category : 'accessing' }
+BioProtein >> defaultAlphabetClass [
+
+	^ BioIUPACProtein
+]

--- a/repository/BioTools/BioRestrictionEnzyme.class.st
+++ b/repository/BioTools/BioRestrictionEnzyme.class.st
@@ -1,0 +1,119 @@
+Class {
+	#name : 'BioRestrictionEnzyme',
+	#superclass : 'BioEnzyme',
+	#instVars : [
+		'site',
+		'cut5',
+		'cut3'
+	],
+	#classVars : [
+		'Registry'
+	],
+	#category : 'BioTools-Restriction',
+	#package : 'BioTools',
+	#tag : 'Restriction'
+}
+
+{ #category : 'accessing' }
+BioRestrictionEnzyme class >> at: aName [
+	^ self registry at: aName
+]
+
+{ #category : 'accessing' }
+BioRestrictionEnzyme class >> register: anEnzyme [
+	self registry at: anEnzyme name put: anEnzyme
+]
+
+{ #category : 'accessing' }
+BioRestrictionEnzyme class >> registry [
+	^ Registry ifNil: [ Registry := Dictionary new ]
+]
+
+{ #category : 'accessing' }
+BioRestrictionEnzyme >> cut3 [
+	^ cut3
+]
+
+{ #category : 'accessing' }
+BioRestrictionEnzyme >> cut3: anObject [
+	cut3 := anObject
+]
+
+{ #category : 'accessing' }
+BioRestrictionEnzyme >> cut5 [
+	^ cut5
+]
+
+{ #category : 'accessing' }
+BioRestrictionEnzyme >> cut5: anObject [
+	cut5 := anObject
+]
+
+{ #category : 'accessing' }
+BioRestrictionEnzyme >> site [
+	^ site
+]
+
+{ #category : 'accessing' }
+BioRestrictionEnzyme >> site: aString [
+	site := aString
+]
+
+{ #category : 'searching' }
+BioRestrictionEnzyme >> regexPattern [
+	"Convert IUPAC site to regex pattern"
+	| map |
+	map := BioIUPACAmbiguousDNA ambiguousLettersMap.
+	^ String streamContents: [ :stream |
+		self site do: [ :char |
+			| upperChar |
+			upperChar := char asUppercase.
+			(map includesKey: upperChar asString)
+				ifTrue: [ stream nextPut: $[; nextPutAll: (map at: upperChar asString); nextPut: $] ]
+				ifFalse: [ stream nextPut: upperChar ] ] ]
+]
+
+{ #category : 'searching' }
+BioRestrictionEnzyme >> searchIn: aSequence [
+	"Search for sites in aSequence (can be BioSequence or BioCircularSequence)"
+	| pattern matches |
+	pattern := self regexPattern.
+	matches := OrderedCollection new.
+
+	"Note: Pharo doesn't have a native Regex that returns all matches with indices easily in some versions,
+	but BioSmalltalk often uses extensions or specific parsers.
+	For the sake of this implementation, we will use a simplified manual search if regex is tricky,
+	but here we assume a standard regex search or manual IUPAC expansion."
+
+	"Simplified manual search for IUPAC"
+	1 to: aSequence size do: [ :i |
+		(self matchesAt: i in: aSequence) ifTrue: [ matches add: i ] ].
+	^ matches
+]
+
+{ #category : 'searching' }
+BioRestrictionEnzyme >> matchesAt: index in: aSequence [
+	| siteSize seqSize |
+	siteSize := self site size.
+	seqSize := aSequence size.
+
+	1 to: siteSize do: [ :i |
+		| siteChar seqChar |
+		siteChar := self site at: i.
+		seqChar := aSequence at: index + i - 1.
+		(self siteChar: siteChar matches: seqChar) ifFalse: [ ^ false ] ].
+	^ true
+]
+
+{ #category : 'searching' }
+BioRestrictionEnzyme >> siteChar: siteChar matches: seqChar [
+	| s c map |
+	s := siteChar asUppercase.
+	c := seqChar asUppercase.
+	s = c ifTrue: [ ^ true ].
+	s = $N ifTrue: [ ^ true ].
+	map := BioIUPACAmbiguousDNA ambiguousLettersMap.
+	(map includesKey: s asString) ifTrue: [
+		^ (map at: s asString) includes: c ].
+	^ false
+]

--- a/repository/BioTools/BioRestrictionEnzyme.class.st
+++ b/repository/BioTools/BioRestrictionEnzyme.class.st
@@ -76,17 +76,16 @@ BioRestrictionEnzyme >> regexPattern [
 { #category : 'searching' }
 BioRestrictionEnzyme >> searchIn: aSequence [
 	"Search for sites in aSequence (can be BioSequence or BioCircularSequence)"
-	| pattern matches |
-	pattern := self regexPattern.
+	| matches upperBound |
 	matches := OrderedCollection new.
 
-	"Note: Pharo doesn't have a native Regex that returns all matches with indices easily in some versions,
-	but BioSmalltalk often uses extensions or specific parsers.
-	For the sake of this implementation, we will use a simplified manual search if regex is tricky,
-	but here we assume a standard regex search or manual IUPAC expansion."
+	"For linear sequences, we must not go beyond site size at the end.
+	Circular sequences handle bounds via modulo in #at: so we search the full size."
+	upperBound := aSequence isCircular
+		ifTrue: [ aSequence size ]
+		ifFalse: [ aSequence size - self site size + 1 ].
 
-	"Simplified manual search for IUPAC"
-	1 to: aSequence size do: [ :i |
+	1 to: upperBound do: [ :i |
 		(self matchesAt: i in: aSequence) ifTrue: [ matches add: i ] ].
 	^ matches
 ]

--- a/repository/BioTools/BioSequence.class.st
+++ b/repository/BioTools/BioSequence.class.st
@@ -953,6 +953,11 @@ BioSequence >> isBioSequence [
 ]
 
 { #category : 'testing' }
+BioSequence >> isCircular [
+	^ false
+]
+
+{ #category : 'testing' }
 BioSequence >> isDNASequence [
 	" Answer <true> if the receiver represents an identifiable biological letter "
 	

--- a/repository/BioTools/BioSequence.extension.st
+++ b/repository/BioTools/BioSequence.extension.st
@@ -1,0 +1,37 @@
+Extension { #name : 'BioSequence' }
+
+{ #category : '*BioTools-Restriction' }
+BioSequence >> digestWith: anEnzymeOrName [
+	"Digest the receiver with an enzyme.
+	anEnzymeOrName can be a BioRestrictionEnzyme or a Symbol/String representing its name."
+	| enzyme |
+	enzyme := anEnzymeOrName isString
+		ifTrue: [ BioRestrictionEnzyme at: anEnzymeOrName ]
+		ifFalse: [ anEnzymeOrName ].
+	^ self digestWithEnzyme: enzyme
+]
+
+{ #category : '*BioTools-Restriction' }
+BioSequence >> digestWithEnzyme: anEnzyme [
+	"Digest the receiver with an enzyme and answer a Collection of fragments."
+	| sites fragments lastIndex |
+	sites := anEnzyme searchIn: self.
+	sites isEmpty ifTrue: [ ^ OrderedCollection with: self ].
+
+	fragments := OrderedCollection new.
+	lastIndex := 1.
+	sites do: [ :siteIndex |
+		| cutIndex |
+		"1-based indexing. siteIndex is the start of the recognition site.
+		cut5 is the offset from the start of the site to the cut position."
+		cutIndex := siteIndex + anEnzyme cut5.
+		fragments add: (self copyFrom: lastIndex to: cutIndex - 1).
+		lastIndex := cutIndex ].
+	fragments add: (self copyFrom: lastIndex to: self size).
+	^ fragments
+]
+
+{ #category : '*BioTools-Restriction' }
+BioSequence >> asCircular [
+	^ BioCircularSequence on: self
+]

--- a/repository/BioTools/BioSequence.extension.st
+++ b/repository/BioTools/BioSequence.extension.st
@@ -1,14 +1,41 @@
 Extension { #name : 'BioSequence' }
 
 { #category : '*BioTools-Restriction' }
-BioSequence >> digestWith: anEnzymeOrName [
-	"Digest the receiver with an enzyme.
-	anEnzymeOrName can be a BioRestrictionEnzyme or a Symbol/String representing its name."
-	| enzyme |
-	enzyme := anEnzymeOrName isString
+BioSequence >> digestWith: anEnzymeCollectionOrName [
+	"Digest the receiver with one or more enzymes.
+	anEnzymeCollectionOrName can be a BioRestrictionEnzyme, a String name, or a Collection of these."
+	| enzymes |
+	enzymes := (anEnzymeCollectionOrName isCollection and: [ anEnzymeCollectionOrName isString not ])
+		ifTrue: [ anEnzymeCollectionOrName collect: [ :each | self resolveEnzyme: each ] ]
+		ifFalse: [ OrderedCollection with: (self resolveEnzyme: anEnzymeCollectionOrName) ].
+	^ self digestWithEnzymes: enzymes
+]
+
+{ #category : '*BioTools-Restriction' }
+BioSequence >> resolveEnzyme: anEnzymeOrName [
+	^ anEnzymeOrName isString
 		ifTrue: [ BioRestrictionEnzyme at: anEnzymeOrName ]
-		ifFalse: [ anEnzymeOrName ].
-	^ self digestWithEnzyme: enzyme
+		ifFalse: [ anEnzymeOrName ]
+]
+
+{ #category : '*BioTools-Restriction' }
+BioSequence >> digestWithEnzymes: aCollectionOfEnzymes [
+	"Digest the receiver with multiple enzymes and answer a Collection of fragments."
+	| allSites fragments lastIndex |
+	allSites := Set new.
+	aCollectionOfEnzymes do: [ :enzyme |
+		(enzyme searchIn: self) do: [ :siteIndex |
+			allSites add: siteIndex + enzyme cut5 ] ].
+
+	allSites isEmpty ifTrue: [ ^ OrderedCollection with: self ].
+
+	fragments := OrderedCollection new.
+	lastIndex := 1.
+	allSites asSortedCollection do: [ :cutIndex |
+		fragments add: (self copyFrom: lastIndex to: cutIndex - 1).
+		lastIndex := cutIndex ].
+	fragments add: (self copyFrom: lastIndex to: self size).
+	^ fragments
 ]
 
 { #category : '*BioTools-Restriction' }
@@ -34,4 +61,11 @@ BioSequence >> digestWithEnzyme: anEnzyme [
 { #category : '*BioTools-Restriction' }
 BioSequence >> asCircular [
 	^ BioCircularSequence on: self
+]
+
+{ #category : '*BioTools-Restriction' }
+BioSequence >> restrictionMapReportWith: aCollectionOfEnzymes [
+	| enzymes |
+	enzymes := aCollectionOfEnzymes collect: [ :each | self resolveEnzyme: each ].
+	^ BioRestrictionMapFormatter new format: self enzymes: enzymes
 ]


### PR DESCRIPTION
This PR ports the restriction enzyme logic from Biopython to BioSmalltalk, re-engineered for Smalltalk-native idioms. It addresses long-standing issues in the original Python implementation by using 1-based indexing, a decorator pattern for circularity, and a flyweight pattern for efficient enzyme management. It also implements a robust many-to-many relationship between enzymes and reactions using an association class for catalytic attributes like Km. Comprehensive tests and a REBASE data parser are included.

---
*PR created automatically by Jules for task [195259426181153767](https://jules.google.com/task/195259426181153767) started by @hernanmd*